### PR TITLE
Add support for 16kb page size

### DIFF
--- a/android-pdf-viewer/build.gradle
+++ b/android-pdf-viewer/build.gradle
@@ -1,17 +1,18 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    namespace 'com.github.barteksc.pdfviewer'
+    compileSdk 35
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 29
+        minSdkVersion 21
+        targetSdkVersion 35
         versionCode 1
         versionName "3.2.0-beta.1"
     }
 }
 
 dependencies {
-    implementation 'androidx.core:core:1.3.1'
+    implementation 'androidx.core:core:1.16.0'
     api 'com.github.TalbotGooday:PdfiumAndroid:1.0.1'
 }

--- a/android-pdf-viewer/build.gradle
+++ b/android-pdf-viewer/build.gradle
@@ -14,5 +14,5 @@ android {
 
 dependencies {
     implementation 'androidx.core:core:1.16.0'
-    api 'com.github.TalbotGooday:PdfiumAndroid:1.0.1'
+    api 'com.github.aldagram:PdfiumAndroid:2.0.0'
 }

--- a/android-pdf-viewer/src/main/AndroidManifest.xml
+++ b/android-pdf-viewer/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      package="com.github.barteksc.pdfviewer">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
               
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,18 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:8.9.3'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url 'https://jitpack.io' }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,12 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    namespace 'com.github.barteksc.sample'
+    compileSdk 35
 
     defaultConfig {
         applicationId "com.pdfviewer"
-        minSdkVersion 16
-        targetSdkVersion 29
+        minSdkVersion 21
+        targetSdkVersion 35
         versionCode 3
         versionName "3.0.0"
     }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	package="com.github.barteksc.sample">
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+		android:maxSdkVersion="32" />
 
 	<application
 		android:icon="@drawable/ic_launcher"
@@ -9,7 +10,7 @@
 		android:theme="@style/Theme.AppCompat.Light">
 		<activity
 			android:name=".PDFViewActivity"
-			android:label="@string/app_name" >
+			android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />

--- a/sample/src/main/java/com/github/barteksc/sample/PDFViewActivity.java
+++ b/sample/src/main/java/com/github/barteksc/sample/PDFViewActivity.java
@@ -80,11 +80,8 @@ public class PDFViewActivity extends AppCompatActivity implements OnPageChangeLi
 
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.pickFile:
-                pickFile();
-
-                break;
+        if (item.getItemId() == R.id.pickFile) {
+            pickFile();
         }
 
         return true;


### PR DESCRIPTION
##  Summary

- Add 16KB page size support: Updated PdfiumAndroid dependency from `TalbotGooday:PdfiumAndroid:1.0.1` to `aldagram:PdfiumAndroid:2.0.0` to support for 16KB page
   size
- Modernize Android build configuration: Updated Android SDK versions, Gradle tools, and dependencies to current standards
